### PR TITLE
can't delete posts

### DIFF
--- a/views/edit.haml
+++ b/views/edit.haml
@@ -23,8 +23,8 @@
 					e.preventDefault()
 					if(confirm('ok?')) {
 						form = $('<form>').attr({method:'POST',action:"/#{current_user.screen_name}/#{@paragraph.id}"})
-						form.append($('<input>').attr({name:'_method',value:'DELETE'}))
-						form.get(0).submit()
+						form.append($('<input>').attr({name:'_method',value:'DELETE'})).css({display: "none"})
+						form.appendTo('body').submit()
 					}
 				})
 :coffeescript


### PR DESCRIPTION
## Summary

Can't delete posts due to specification change of google chrome. (see #10)

## Tests

Tested manually that users can delete posts manually.