### PR TITLE
don't hide edit button on mouse leave at list page

### DIFF
--- a/views/list.haml
+++ b/views/list.haml
@@ -35,11 +35,11 @@
       $('.actions').hover ()->
         timer = setTimeout ()=>
           $('.link', @).hide()
-          $('.edit', @).show().css('visibility', 'visible')
+          $('.edit', @).hide()
         , 1500
       , ()->
         $('.link', @).show()
-        $('.edit', @).hide().css('visibility', 'hidden')
+        $('.edit', @).show()
         clearTimeout timer
       $('.edit, .link').click ()->
         clearTimeout timer


### PR DESCRIPTION
## Summary

* don't hide edit button on mouse leave at list page

## Tests

* see if edit button is not hidden on mouse leave at list page